### PR TITLE
fix: enforce exact single-use token approvals and bound callback spend in SwapCallV2 (#1)

### DIFF
--- a/contracts/abstract/SwapCallV2.sol
+++ b/contracts/abstract/SwapCallV2.sol
@@ -138,7 +138,10 @@ abstract contract SwapCallV2 {
         uint256 value = callParam.extraNativeAmount + _approveToken(_token, callParam.approveTo, _amount);
         (bool result, ) = target.call{value: value}(callPayload);
         if (!result) revert Errors.CALL_BACK_FAIL();
+        _removeTokenApproval(_token, callParam.approveTo);
         callAmount = callAmount - _getBalance(_token, self);
+        if (!_isNative(_token) && callAmount > _amount) revert Errors.CALL_AMOUNT_INVALID();
+
     }
 
     function _checkApproval(address _callTo, bytes4 sig) private view {
@@ -245,6 +248,7 @@ abstract contract SwapCallV2 {
             _checkApproval(target, sig);
             uint256 value = _approveToken(_srcToken, mix.approveTo, _amount);
             (result, ) = target.call{value: value}(callData);
+            _removeTokenApproval(_srcToken, mix.approveTo);
             if (!result) break;
             unchecked {
                 ++i;
@@ -280,17 +284,21 @@ abstract contract SwapCallV2 {
         _checkApproval(_callTo, sig);
         uint256 value = _approveToken(_token, _approveTo, _amount);
         (result, ) = _callTo.call{value: value}(callData);
+        _removeTokenApproval(_token, _approveTo);
     }
 
     function _approveToken(address token, address spender, uint256 amount) internal returns (uint256 value) {
         if (_isNative(token)) {
             value = amount;
         } else {
-            uint256 allowance = IERC20(token).allowance(address(this), spender);
-            if (allowance < amount) {
-                if(!approved[spender]) revert Errors.NO_APPROVE();
-                IERC20(token).forceApprove(spender, amount);
-            }
+            if(!approved[spender]) revert Errors.NO_APPROVE();
+            IERC20(token).forceApprove(spender, amount);
+        }
+    }
+
+    function _removeTokenApproval(address token, address spender) internal {
+        if (!_isNative(token)) {
+            IERC20(token).forceApprove(spender, 0);
         }
     }
 


### PR DESCRIPTION
fix: enforce exact single-use token approvals and bound callback spend in SwapCallV2 (#1)

- _approveToken: always set the exact allowance and require the spender to be whitelisted (removed the "skip when allowance >= amount" branch)
- add _removeTokenApproval and revoke the allowance after every external call (_callBack, _makeMixSwap, _makeAggFill)
- _callBack: revert when callAmount exceeds the input amount for ERC20 tokens