### PR TITLE
fix: skip redundant approve(0) in _removeTokenApproval when allowance is already zero

### DIFF
--- a/contracts/abstract/SwapCallV2.sol
+++ b/contracts/abstract/SwapCallV2.sol
@@ -298,7 +298,8 @@ abstract contract SwapCallV2 {
 
     function _removeTokenApproval(address token, address spender) internal {
         if (!_isNative(token)) {
-            IERC20(token).forceApprove(spender, 0);
+            uint256 allowance = IERC20(token).allowance(address(this), spender);
+            if (allowance > 0) IERC20(token).forceApprove(spender, 0);
         }
     }
 


### PR DESCRIPTION
fix: skip redundant approve(0) in _removeTokenApproval when allowance is already zero

Read the current allowance first and only call forceApprove(spender, 0) when it is non-zero.